### PR TITLE
Always return an ordered list

### DIFF
--- a/lib/puppet/parser/functions/get_dimensions.rb
+++ b/lib/puppet/parser/functions/get_dimensions.rb
@@ -28,7 +28,7 @@ if aws_integration
         end
 end
 unless dimension_list.empty?
-        dimension_list.each {|key, value| dimensions << "sfxdim_#{key}=#{value}&"}
+    dimension_list.sort_by { |k| k }.each { |key, value| dimensions << "sfxdim_#{key}=#{value}&" }
 end
 dimensions[0...-1]
 end


### PR DESCRIPTION
By not sorting the hash key, this will most likely change on every
puppet run.