### PR TITLE
Additional signalfx fixes

### DIFF
--- a/manifests/plugins/signalfx.pp
+++ b/manifests/plugins/signalfx.pp
@@ -17,7 +17,6 @@ class collectd::plugins::signalfx(
 
   $dimensions = get_dimensions($dimension_list, $aws_integration)
   $signalfx_api_endpoint_with_dimensions = "${signalfx_api_endpoint}${dimensions}"
-  notify {"Collectd will transmit metrics to this url: ${signalfx_api_endpoint_with_dimensions}":}
 
   collectd::check_and_install_package { 'signalfx-collectd-plugin':
     before  => File['load Signalfx plugin']

--- a/templates/collectd.conf.erb
+++ b/templates/collectd.conf.erb
@@ -54,7 +54,7 @@ LoadPlugin logfile
 
 <%- @loadplugins.each do |plugin, loadplugin_config| -%>
 <LoadPlugin <%= plugin %>>
-  <%- loadplugin_config.each do |key,value| -%>
+  <%- loadplugin_config.sort_by { |k| k }.each do |key,value| -%>
   <%= key -%> <%= value %>
   <%- end -%>
 </LoadPlugin>

--- a/templates/filtering.conf.erb
+++ b/templates/filtering.conf.erb
@@ -50,7 +50,7 @@ LoadPlugin match_regex
 <%- rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/apache/10-apache.conf.erb
+++ b/templates/plugins/apache/10-apache.conf.erb
@@ -3,7 +3,7 @@ LoadPlugin "apache"
 <Plugin "apache">
     <%- @modules.each do |module_instance, module_config| -%>
     <Instance "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Instance>
@@ -28,7 +28,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/cassandra/20-cassandra.conf.erb
+++ b/templates/plugins/cassandra/20-cassandra.conf.erb
@@ -175,7 +175,7 @@
 
 	<%- @modules.each do |module_instance, module_config| -%>
 	<Connection "<%= module_instance %>">
-	<%- module_config.each do |key,value| -%>
+	<%- module_config.sort_by { |k| k }.each do |key,value| -%>
 	  <%- if key == 'collect_metrics' -%>
 
 	  <%- value.each do |collectname| -%>

--- a/templates/plugins/df/10-df.conf.erb
+++ b/templates/plugins/df/10-df.conf.erb
@@ -2,7 +2,7 @@
 LoadPlugin df
 <Plugin "df">
 <%- @modules.each do |module_instance, module_config| -%>
-  <%- module_config.each do |key,value| -%>
+  <%- module_config.sort_by { |k| k }.each do |key,value| -%>
       <%= key -%> <%= value %>
   <%- end -%>
 <%- end -%>
@@ -26,7 +26,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/disk/10-disk.conf.erb
+++ b/templates/plugins/disk/10-disk.conf.erb
@@ -2,7 +2,7 @@
 LoadPlugin disk
 <Plugin "disk">
 <%- @modules.each do |module_instance, module_config| -%>
-  <%- module_config.each do |key,value| -%>
+  <%- module_config.sort_by { |k| k }.each do |key,value| -%>
       <%= key -%> <%= value %>
   <%- end -%>
 <%- end -%>
@@ -26,7 +26,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/docker/10-docker.conf.erb
+++ b/templates/plugins/docker/10-docker.conf.erb
@@ -8,7 +8,7 @@ LoadPlugin python
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -33,7 +33,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/elasticsearch/20-elasticsearch.conf.erb
+++ b/templates/plugins/elasticsearch/20-elasticsearch.conf.erb
@@ -10,7 +10,7 @@
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -35,7 +35,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/iostat/10-iostat.conf.erb
+++ b/templates/plugins/iostat/10-iostat.conf.erb
@@ -9,7 +9,7 @@
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -34,7 +34,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/kafka/20-kafka.conf.erb
+++ b/templates/plugins/kafka/20-kafka.conf.erb
@@ -155,7 +155,7 @@
 
 	<%- @modules.each do |module_instance, module_config| -%>
 	<Connection "<%= module_instance %>">
-	<%- module_config.each do |key,value| -%>
+	<%- module_config.sort_by { |k| k }.each do |key,value| -%>
 	  <%- if key == 'collect_metrics' -%>
 
 	  <%- value.each do |collectname| -%>

--- a/templates/plugins/memcached/10-memcached.conf.erb
+++ b/templates/plugins/memcached/10-memcached.conf.erb
@@ -2,7 +2,7 @@
 LoadPlugin memcached
 <Plugin "memcached">
 <%- @modules.each do |module_instance, module_config| -%>
-  <%- module_config.each do |key,value| -%>
+  <%- module_config.sort_by { |k| k }.each do |key,value| -%>
       <%= key -%> <%= value %>
   <%- end -%>
 <%- end -%>
@@ -26,7 +26,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/mesos/10-mesos-master.conf.erb
+++ b/templates/plugins/mesos/10-mesos-master.conf.erb
@@ -10,7 +10,7 @@
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -35,7 +35,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/mongodb/10-mongodb.conf.erb
+++ b/templates/plugins/mongodb/10-mongodb.conf.erb
@@ -6,7 +6,7 @@ LoadPlugin python
     Import "mongodb"
     <%- @modules.each do |module_instance, module_config| -%>
     <Module <%= module_instance %>>
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -31,7 +31,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/mysql/mysql.conf.erb
+++ b/templates/plugins/mysql/mysql.conf.erb
@@ -21,7 +21,7 @@ LoadPlugin mysql
 <Plugin mysql>
   <% @modules.each do |module_instance, module_config| -%>
   <Database <%= module_instance -%> >
-    <% module_config.each do |key,value| -%>
+    <% module_config.sort_by { |k| k }.each do |key,value| -%>
     <%= key -%> <%= value %>
     <% end -%>
   </Database>
@@ -46,7 +46,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/nginx/10-nginx.conf.erb
+++ b/templates/plugins/nginx/10-nginx.conf.erb
@@ -2,7 +2,7 @@
 LoadPlugin nginx
 <Plugin "nginx">
 <%- @modules.each do |module_instance, module_config| -%>
-  <%- module_config.each do |key,value| -%>
+  <%- module_config.sort_by { |k| k }.each do |key,value| -%>
       <%= key -%> <%= value %>
   <%- end -%>
 <%- end -%>
@@ -26,7 +26,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/postgresql/10-postgresql.conf.erb
+++ b/templates/plugins/postgresql/10-postgresql.conf.erb
@@ -18,7 +18,7 @@ LoadPlugin postgresql
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Database "<%= module_instance %>">
-    <%- module_config.each do |key,value| -%>
+    <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%- if key == 'queries' -%>
 
         <%- value.each do |queryname| -%>
@@ -50,7 +50,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/rabbitmq/rabbitmq.conf.erb
+++ b/templates/plugins/rabbitmq/rabbitmq.conf.erb
@@ -38,7 +38,7 @@ LoadPlugin python
 
   <% @modules.each do |instance,config| -%>
     <Module rabbitmq>
-    <% config.each do |key,value| -%>
+    <% config.sort_by { |k| k }.each do |key,value| -%>
     <%= key -%> <%= value %>
     <% end -%>
   </Module>
@@ -63,7 +63,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/redis/10-redis_master.conf.erb
+++ b/templates/plugins/redis/10-redis_master.conf.erb
@@ -9,7 +9,7 @@
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -34,7 +34,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/varnish/10-varnish.conf.erb
+++ b/templates/plugins/varnish/10-varnish.conf.erb
@@ -3,7 +3,7 @@ LoadPlugin varnish
 <Plugin varnish>
   <% @modules.each do |mondule_instance, module_config| -%>
   <Instance>
-    <% module_config.each do |key,value| -%>
+    <% module_config.sort_by { |k| k }.each do |key,value| -%>
     <%= key -%> <%= value %>
     <% end -%>
   </Instance>
@@ -28,7 +28,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/vmstat/10-vmstat.conf.erb
+++ b/templates/plugins/vmstat/10-vmstat.conf.erb
@@ -9,7 +9,7 @@
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -34,7 +34,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>

--- a/templates/plugins/zookeeper/20-zookeeper.conf.erb
+++ b/templates/plugins/zookeeper/20-zookeeper.conf.erb
@@ -9,7 +9,7 @@
 
     <%- @modules.each do |module_instance, module_config| -%>
     <Module "<%= module_instance %>">
-        <%- module_config.each do |key,value| -%>
+        <%- module_config.sort_by { |k| k }.each do |key,value| -%>
         <%= key -%> <%= value %>
         <%- end -%>
     </Module>
@@ -35,7 +35,7 @@ LoadPlugin match_regex
 <%- @filter_metric_rules.each do |rule_instance, rule| -%>
     <Rule "<%= rule_instance -%>">
       <Match "regex">
-      <%- rule.each do |key,value| -%>
+      <%- rule.sort_by { |k| k }.each do |key,value| -%>
         <%- if key != "Type" -%>
         <%= key -%> "<%= value %>"
 	<%- else -%>


### PR DESCRIPTION
1. Stop outputting where collectd will transmit metrics. Pollutes puppet run output on every run.
1. Make sure that keys are ordered when looping to generate config files. Otherwise, this will cause collectd to potentially restart on every puppet run.